### PR TITLE
In the case of SimpleRequestResponse messages, talaria uses transacti…

### DIFF
--- a/src/tr1d1um/conversion_utils.go
+++ b/src/tr1d1um/conversion_utils.go
@@ -62,6 +62,7 @@ type EncodingHelper struct{}
 //ConversionWDMP implements the definitions defined in ConversionTool
 type ConversionWDMP struct {
 	encodingHelper EncodingTool
+	WRPSource string
 }
 
 //The following functions with names of the form {command}FlavorFormat serve as the low level builders of WDMP objects
@@ -193,11 +194,17 @@ func (cw *ConversionWDMP) GetConfiguredWRP(wdmp []byte, pathVars Vars, header ht
 		Type:            wrp.SimpleRequestResponseMessageType,
 		ContentType:     header.Get("Content-Type"),
 		Payload:         wdmp,
-		Source:          WRPSource + "/" + service,
+		Source:          cw.GetWRPSource() + "/" + service,
 		Destination:     deviceID + "/" + service,
 		TransactionUUID: GetOrGenTID(header),
 	}
 	return
+}
+
+// GetWRPSource returns the Source that should be used in every
+// WRP transaction message
+func (cw *ConversionWDMP) GetWRPSource() string {
+	return cw.WRPSource
 }
 
 /*   Encoding Helper methods below */

--- a/src/tr1d1um/conversion_utils_test.go
+++ b/src/tr1d1um/conversion_utils_test.go
@@ -93,7 +93,7 @@ func TestGetFlavorFormat(t *testing.T) {
 
 func TestSetFlavorFormat(t *testing.T) {
 	assert := assert.New(t)
-	c := ConversionWDMP{&EncodingHelper{}}
+	c := ConversionWDMP{encodingHelper:&EncodingHelper{}, WRPSource: "dns:machineDNS"}
 	commonURL := "http://device/config?k=v"
 	var req *http.Request
 
@@ -163,7 +163,7 @@ func TestSetFlavorFormat(t *testing.T) {
 func TestDeleteFlavorFormat(t *testing.T) {
 	assert := assert.New(t)
 	commonVars := Vars{"param": "rowName", "emptyParam": ""}
-	c := ConversionWDMP{&EncodingHelper{}}
+	c := ConversionWDMP{encodingHelper:&EncodingHelper{}, WRPSource: "dns:machineDNS"}
 
 	t.Run("NoRowName", func(t *testing.T) {
 		_, err := c.DeleteFlavorFormat(Vars{}, "param")
@@ -188,7 +188,7 @@ func TestReplaceFlavorFormat(t *testing.T) {
 	assert := assert.New(t)
 	commonVars := Vars{"uThere?": "yes!"}
 	emptyVars := Vars{}
-	c := ConversionWDMP{&EncodingHelper{}}
+	c := ConversionWDMP{encodingHelper:&EncodingHelper{}, WRPSource: "dns:machineDNS"}
 
 	t.Run("TableNotProvided", func(t *testing.T) {
 		_, err := c.ReplaceFlavorFormat(nil, emptyVars, "uThere?")
@@ -226,7 +226,7 @@ func TestAddFlavorFormat(t *testing.T) {
 	assert := assert.New(t)
 	emptyVars := Vars{}
 
-	c := ConversionWDMP{&EncodingHelper{}}
+	c := ConversionWDMP{encodingHelper:&EncodingHelper{}, WRPSource: "dns:machineDNS"}
 
 	t.Run("TableNotProvided", func(t *testing.T) {
 		_, err := c.AddFlavorFormat(nil, emptyVars, "uThere?")
@@ -433,7 +433,7 @@ func TestGetConfiguredWRP(t *testing.T) {
 	service := "webpaService"
 	tid := "uniqueVal"
 
-	c := ConversionWDMP{}
+	c := ConversionWDMP{WRPSource:"dns:source"}
 
 	inputVars := Vars{"service": service, "deviceid": deviceID}
 	inputHeader := http.Header{}
@@ -441,7 +441,7 @@ func TestGetConfiguredWRP(t *testing.T) {
 	inputHeader.Set(HeaderWPATID, tid)
 	inputWdmpPayload := []byte(`{irrelevantFormat}`)
 
-	expectedSource := WRPSource + "/" + service
+	expectedSource := "dns:source/" + service
 	expectedDest := deviceID + "/" + service
 
 	wrpMsg := c.GetConfiguredWRP(inputWdmpPayload, inputVars, inputHeader)

--- a/src/tr1d1um/tr1d1um.go
+++ b/src/tr1d1um/tr1d1um.go
@@ -173,7 +173,7 @@ func SetUpHandler(v *viper.Viper, logger log.Logger) (cHandler *ConversionHandle
 
 	cHandler = &ConversionHandler{
 		Requester:      &ContextTimeoutRequester{&http.Client{Timeout: clientTimeout}},
-		wdmpConvert:    &ConversionWDMP{&EncodingHelper{}},
+		wdmpConvert:    &ConversionWDMP{encodingHelper: &EncodingHelper{}, WRPSource: v.GetString("WRPSource")},
 		sender:         &Tr1SendAndHandle{log: logger, NewHTTPRequest: http.NewRequest, respTimeout: respTimeout},
 		encodingHelper: &EncodingHelper{}, logger: logger,
 		targetURL:     v.GetString("targetURL"),

--- a/src/tr1d1um/tr1d1um_response.go
+++ b/src/tr1d1um/tr1d1um_response.go
@@ -18,7 +18,7 @@ const (
 //RDKResponse will serve as the struct to read in
 //results coming from some RDK device
 type RDKResponse struct {
-	StatusCode int `json:"StatusCode"`
+	StatusCode int `json:"statusCode"`
 }
 
 //writeResponse is a tiny helper function that passes responses (In Json format only for now)

--- a/src/tr1d1um/wdmp_type.go
+++ b/src/tr1d1um/wdmp_type.go
@@ -41,7 +41,7 @@ const (
 
 	ErrUnsuccessfulDataParse = "Unsuccessful Data Parse"
 
-	WRPSource = "dns:tr1d1um.webpa.comcast.net"
+	WRPSource = "dns:tr1d1um.xmidt.comcast.net"
 )
 
 //GetWDMP serves as container for data used for the GET-flavored commands

--- a/src/tr1d1um/wdmp_type.go
+++ b/src/tr1d1um/wdmp_type.go
@@ -40,8 +40,6 @@ const (
 	HeaderWPATID        = "X-WebPA-Transaction-Id"
 
 	ErrUnsuccessfulDataParse = "Unsuccessful Data Parse"
-
-	WRPSource = "dns:tr1d1um.xmidt.comcast.net"
 )
 
 //GetWDMP serves as container for data used for the GET-flavored commands


### PR DESCRIPTION
…on IDs instead of source/dest swapping but changing to correct DNS anyways.