### PR TITLE
Hotfix/header forwarding

### DIFF
--- a/src/tr1d1um/communication.go
+++ b/src/tr1d1um/communication.go
@@ -99,6 +99,8 @@ func (tr1 *Tr1SendAndHandle) HandleResponse(err error, respFromServer *http.Resp
 		return
 	}
 
+	ForwardHeadersByPrefix("X", respFromServer, tr1Resp)
+
 	//as a client, we are responsible to close the body after it gets read below
 	defer respFromServer.Body.Close()
 	bodyBytes, errReading := ioutil.ReadAll(respFromServer.Body)
@@ -131,7 +133,6 @@ func (tr1 *Tr1SendAndHandle) HandleResponse(err error, respFromServer *http.Resp
 		errorLogger.Log(logging.MessageKey(), "could not extract payload from wrp body", logging.ErrorKey(), errDecoding)
 	}
 
-	ForwardHeadersByPrefix("X", respFromServer, tr1Resp)
 	return
 }
 

--- a/src/tr1d1um/http.go
+++ b/src/tr1d1um/http.go
@@ -256,7 +256,7 @@ func (validator *TR1RequestValidator) isValidRequest(URLVars map[string]string, 
 
 	//check device id
 	if _, err := device.ParseID(URLVars["deviceid"]); err != nil {
-		WriteResponseWriter(fmt.Sprintf("Invalid devideID: %s", err.Error()), http.StatusBadRequest, origin)
+		WriteResponseWriter(fmt.Sprintf("Invalid deviceID: %s", err.Error()), http.StatusBadRequest, origin)
 		logging.Error(validator).Log(logging.ErrorKey(), err.Error(), logging.MessageKey(), "Invalid deviceID")
 		return false
 	}


### PR DESCRIPTION
Fixes the following issues:

- [x] Tr1d1um was not forwarding the required headers in cases XMiDT returned non-200 status code.

- [x] Typo in Tr1d1um message response for invalid device IDs