### PR TITLE
Read endpoint scheme from the configuration

### DIFF
--- a/src/tr1d1um/tr1d1um.go
+++ b/src/tr1d1um/tr1d1um.go
@@ -166,8 +166,13 @@ func ConfigureWebHooks(baseRouter *mux.Router, root *mux.Router, preHandler *ali
 	baseRouter.Handle("/hook", preHandler.ThenFunc(webHookRegistry.UpdateRegistry))
 	baseRouter.Handle("/hooks", preHandler.ThenFunc(webHookRegistry.GetRegistry))
 
+	scheme := v.GetString("scheme")
+	if len(scheme) < 1 {
+		scheme = "https"
+	}
+
 	selfURL := &url.URL{
-		Scheme: "https",
+		Scheme: scheme,
 		Host:   v.GetString("fqdn") + v.GetString("primary.address"),
 	}
 


### PR DESCRIPTION
This change allows us to configure Tr1dium to receive AWS notifications in an insecure endpoint.
By default it will use HTTPS.

Although we do not use it in production scenarios, this is useful in development scenarios where we do not use HTTPS.