### PR TITLE
Feature/use sns wait for dns

### DIFF
--- a/src/glide.lock
+++ b/src/glide.lock
@@ -1,5 +1,5 @@
-hash: 9a3e95095cc54644fe126fdcbefefdb6cf3ae817f66d81c0fc5708161059f3ec
-updated: 2018-05-12T15:27:41.820586-07:00
+hash: bf9afb2ac3e9221a3482970207370ec43e0c39acc8b5637911aad63497a9af71
+updated: 2018-07-13T17:05:17.861847-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 7be45195c3af1b54a609812f90c05a7e492e2491
@@ -38,7 +38,7 @@ imports:
   subpackages:
   - linux
 - name: github.com/Comcast/webpa-common
-  version: bd4c644760d8d708804f87461c513271c046de4a
+  version: 1fe1b8d5a34a554962905502ca8c947a250fc709
   subpackages:
   - concurrent
   - convey
@@ -59,7 +59,7 @@ imports:
   - xlistener
   - xmetrics
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/fsnotify/fsnotify
@@ -91,7 +91,7 @@ imports:
 - name: github.com/go-stack/stack
   version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
 - name: github.com/golang/protobuf
-  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
+  version: 9eb2c01ac278a5d89ce4b2be68fe4500955d8179
   subpackages:
   - proto
 - name: github.com/gorilla/context
@@ -112,7 +112,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/influxdata/influxdb
-  version: 5ac5fe2f9c39c77a6834b2ed80df840d8e7f7b39
+  version: 48797873ee24fc1dcb5a63f23474d3210f6d68c5
   subpackages:
   - client/v2
   - models
@@ -126,17 +126,17 @@ imports:
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/magiconair/properties
-  version: 2c9e9502788518c97fe44e8955cd069417ee89df
+  version: c2353362d570a7bfa228149c62842019201cfb71
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: 00c29f56e2386353d58c599509e8dc3801b0d716
+  version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
 - name: github.com/pelletier/go-toml
-  version: 66540cf1fcd2c3aee6f6787dfa32a6ae9a870f12
+  version: c01d1270ff3e442a8a57cddc1c92dc1138598194
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -149,7 +149,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: d811d2e9bf898806ecfb6ef6296774b13ffc314c
+  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -167,7 +167,7 @@ imports:
   - jws
   - jwt
 - name: github.com/spf13/afero
-  version: 63644898a8da0bc22138abf860edaf5277b6102e
+  version: 787d034dfe70e44075ccc060d346146ef53270ad
   subpackages:
   - mem
 - name: github.com/spf13/cast
@@ -179,9 +179,9 @@ imports:
 - name: github.com/spf13/viper
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
+  version: 9e1dfc121bca96d392da5d00591953bdb54ab306
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
   - linux
@@ -194,11 +194,11 @@ imports:
 - name: github.com/VividCortex/gohistogram
   version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
 - name: golang.org/x/sys
-  version: 78d5f264b493f125018180c204871ecf58a2dce1
+  version: 7138fd3d9dc8335c567ca206f4333fb75eb05d56
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 7922cc490dd5a7dbaa7fd5d6196b49db59ac042f
+  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
   subpackages:
   - transform
   - unicode/norm

--- a/src/glide.yaml
+++ b/src/glide.yaml
@@ -2,4 +2,4 @@ package: .
 homepage: https://github.com/Comcast/tr1d1um
 import:
 - package: github.com/Comcast/webpa-common
-  version: bd4c644760d8d708804f87461c513271c046de4a
+  version: 1fe1b8d5a34a554962905502ca8c947a250fc709

--- a/src/tr1d1um/tr1d1um.go
+++ b/src/tr1d1um/tr1d1um.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"

--- a/src/tr1d1um/tr1d1um.go
+++ b/src/tr1d1um/tr1d1um.go
@@ -224,21 +224,14 @@ func tr1d1um(arguments []string) (exitCode int) {
 	}
 
 	if snsFactory != nil {
-
-		/// This chunk of code is intended to show that failures in SNS confirmation
-		/// are due to the fact that SNS sends confirmation requests to this server
-		/// before the server is fully running.
-		/// The hypothesis is that in other servers such as caduceus, we do not see this issue that often due to
-		/// getting "lucky" that ServeTLS in another goroutine finishing before PrepareAndStart())
-		if err = serverReady(v.GetString("server")+v.GetString("primary.address"), errorLogger); err == nil {
+		// wait for DNS to propagate before subscribing to SNS
+		if err = snsFactory.DnsReady(); err == nil {
 			infoLogger.Log(logging.MessageKey(), "server is ready to take on subscription confirmations")
 			snsFactory.PrepareAndStart()
 		} else {
 			errorLogger.Log(logging.MessageKey(), "Server was not ready within a time constraint. SNS confirmation could not happen",
 				logging.ErrorKey(), err)
 		}
-		///
-
 	}
 
 	signal.Notify(signals)
@@ -358,42 +351,4 @@ func getValidator(v *viper.Viper, m *secure.JWTValidationMeasures) (validator se
 
 func main() {
 	os.Exit(tr1d1um(os.Args))
-}
-
-//serverReady blocks until the primary server is up and running or
-//until the timeout is reached
-func serverReady(endpoint string, logger log.Logger) (e error) {
-	var ctx, cancel = context.WithTimeout(context.Background(), time.Minute*10)
-	defer cancel()
-
-	var check = func() <-chan struct{} {
-		var channel = make(chan struct{})
-
-		go func(c chan struct{}) {
-			var (
-				err  error
-				conn net.Conn
-			)
-
-			for {
-				if conn, err = net.Dial("tcp", endpoint); err == nil {
-					conn.Close()
-					c <- struct{}{}
-					return
-				}
-				logger.Log(logging.MessageKey(), "checking if server is ready", "endpoint", endpoint, logging.ErrorKey(), err)
-				time.Sleep(time.Second)
-			}
-		}(channel)
-
-		return channel
-	}
-
-	select {
-	case <-check():
-	case <-ctx.Done():
-		e = ctx.Err()
-	}
-
-	return
 }


### PR DESCRIPTION
bumped webpa-common and now using webhook/aws DnsReady code to wait for DNS to propagate before attempting to subscribe to SNS.