### PR TITLE
Hooks: fixup due to change in webpa/aws/sns Initalizer

### DIFF
--- a/src/tr1d1um/hooks/hooks.go
+++ b/src/tr1d1um/hooks/hooks.go
@@ -27,6 +27,7 @@ type Options struct {
 	HooksFactory *webhook.Factory
 	Log          kitlog.Logger
 	Scheme       string
+	SoAprovider  string
 }
 
 //ConfigHandler configures a given handler with webhook endpoints
@@ -42,5 +43,5 @@ func ConfigHandler(o *Options) {
 	}
 
 	//Initialize must take the router without any prefixes
-	o.HooksFactory.Initialize(o.RootRouter, selfURL, hooksHandler, o.Log, o.M, nil)
+	o.HooksFactory.Initialize(o.RootRouter, selfURL, o.SoAprovider, hooksHandler, o.Log, o.M, nil)
 }


### PR DESCRIPTION
A change in webpa/aws/sns _Initalizer_ needed to be included in Tr1d1um.  Review and comment if SoA provider should not be an option. 