### PR TITLE
feat: add configurable bearer-token fingerprinting for request logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ const (
 	authAcquirerKey                   = "authAcquirer"
 	webhookConfigKey                  = "webhook"
 	tracingConfigKey                  = "tracing"
+	fingerprintCredsKey               = "fingerprintCreds"
 )
 
 var (

--- a/routes.go
+++ b/routes.go
@@ -27,6 +27,7 @@ import (
 	"github.com/xmidt-org/touchstone"
 	"github.com/xmidt-org/touchstone/touchhttp"
 	"github.com/xmidt-org/tr1d1um/stat"
+	"github.com/xmidt-org/tr1d1um/transaction"
 	"github.com/xmidt-org/tr1d1um/translation"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.uber.org/fx"
@@ -49,9 +50,10 @@ type primaryEndpointIn struct {
 	Logger                      *zap.Logger
 	StatServiceOptions          *stat.ServiceOptions
 	TranslationOptions          *translation.ServiceOptions
-	AuthAcquirer                authAcquirerConfig `name:"authAcquirer"`
-	ReducedLoggingResponseCodes []int              `name:"reducedLoggingResponseCodes"`
-	TranslationServices         []string           `name:"supportedServices"`
+	AuthAcquirer                authAcquirerConfig            `name:"authAcquirer"`
+	ReducedLoggingResponseCodes []int                         `name:"reducedLoggingResponseCodes"`
+	TranslationServices         []string                      `name:"supportedServices"`
+	BearerFingerprint             transaction.FingerprintConfig `name:"bearerFingerprint"`
 }
 
 type handleWebhookRoutesIn struct {
@@ -126,6 +128,10 @@ func provideServers() fx.Option {
 			fx.Annotated{
 				Name:   "reducedLoggingResponseCodes",
 				Target: arrange.UnmarshalKey(reducedTransactionLoggingCodesKey, []int{}),
+			},
+			fx.Annotated{
+				Name:   "bearerFingerprint",
+				Target: arrange.UnmarshalKey(fingerprintCredsKey, transaction.FingerprintConfig{}),
 			},
 			fx.Annotated{
 				Name:   "api_router",
@@ -212,6 +218,7 @@ func handlePrimaryEndpoint(in primaryEndpointIn) {
 		Authenticate:                &in.AuthChain,
 		Log:                         in.Logger,
 		ReducedLoggingResponseCodes: in.ReducedLoggingResponseCodes,
+		BearerFingerprint:             in.BearerFingerprint,
 	})
 	translation.ConfigHandler(&translation.Options{
 		S:                           ts,
@@ -220,6 +227,7 @@ func handlePrimaryEndpoint(in primaryEndpointIn) {
 		Log:                         in.Logger,
 		ValidServices:               in.TranslationServices,
 		ReducedLoggingResponseCodes: in.ReducedLoggingResponseCodes,
+		BearerFingerprint:             in.BearerFingerprint,
 	})
 }
 

--- a/routes.go
+++ b/routes.go
@@ -53,7 +53,7 @@ type primaryEndpointIn struct {
 	AuthAcquirer                authAcquirerConfig            `name:"authAcquirer"`
 	ReducedLoggingResponseCodes []int                         `name:"reducedLoggingResponseCodes"`
 	TranslationServices         []string                      `name:"supportedServices"`
-	BearerFingerprint             transaction.FingerprintConfig `name:"bearerFingerprint"`
+	BearerFingerprint           transaction.FingerprintConfig `name:"bearerFingerprint"`
 }
 
 type handleWebhookRoutesIn struct {
@@ -218,7 +218,7 @@ func handlePrimaryEndpoint(in primaryEndpointIn) {
 		Authenticate:                &in.AuthChain,
 		Log:                         in.Logger,
 		ReducedLoggingResponseCodes: in.ReducedLoggingResponseCodes,
-		BearerFingerprint:             in.BearerFingerprint,
+		BearerFingerprint:           in.BearerFingerprint,
 	})
 	translation.ConfigHandler(&translation.Options{
 		S:                           ts,
@@ -227,7 +227,7 @@ func handlePrimaryEndpoint(in primaryEndpointIn) {
 		Log:                         in.Logger,
 		ValidServices:               in.TranslationServices,
 		ReducedLoggingResponseCodes: in.ReducedLoggingResponseCodes,
-		BearerFingerprint:             in.BearerFingerprint,
+		BearerFingerprint:           in.BearerFingerprint,
 	})
 }
 

--- a/stat/transport.go
+++ b/stat/transport.go
@@ -38,6 +38,7 @@ type Options struct {
 	Authenticate                *alice.Chain
 	Log                         *zap.Logger
 	ReducedLoggingResponseCodes []int
+	BearerFingerprint             transaction.FingerprintConfig
 }
 
 // ConfigHandler sets up the server that powers the stat service
@@ -55,7 +56,7 @@ func ConfigHandler(c *Options) {
 		opts...,
 	)
 
-	c.APIRouter.Handle("/device/{deviceid}/stat", c.Authenticate.Then(candlelight.EchoFirstTraceNodeInfo(candlelight.Tracing{}.Propagator(), false)(transaction.Welcome(statHandler)))).
+	c.APIRouter.Handle("/device/{deviceid}/stat", c.Authenticate.Then(candlelight.EchoFirstTraceNodeInfo(candlelight.Tracing{}.Propagator(), false)(transaction.Welcome(c.BearerFingerprint)(statHandler)))).
 		Methods(http.MethodGet)
 }
 

--- a/stat/transport.go
+++ b/stat/transport.go
@@ -38,7 +38,7 @@ type Options struct {
 	Authenticate                *alice.Chain
 	Log                         *zap.Logger
 	ReducedLoggingResponseCodes []int
-	BearerFingerprint             transaction.FingerprintConfig
+	BearerFingerprint           transaction.FingerprintConfig
 }
 
 // ConfigHandler sets up the server that powers the stat service

--- a/tr1d1um.yaml
+++ b/tr1d1um.yaml
@@ -121,6 +121,20 @@ logging:
   encoding: json
 
 ##############################################################################
+# Credential Fingerprinting
+##############################################################################
+# fingerprintCreds controls how inbound Bearer credentials are fingerprinted
+# into per-request log fields for tracing/correlation. Defaults are off; set
+# one or both sub-keys to emit the corresponding field on every request log.
+#   - lastNdigits: when > 0, log the last N characters of the token as
+#     "credSuffix". Tokens shorter than N are not logged.
+#   - sha256: when true, log the hex-encoded sha256 of the token as "credSHA".
+# (Optional)
+# fingerprintCreds:
+#   sha256: false
+#   lastNdigits: 0
+
+##############################################################################
 # Webhooks Related Configuration
 ##############################################################################
 # webhook provides configuration for storing and obtaining webhook

--- a/transaction/transactor.go
+++ b/transaction/transactor.go
@@ -6,7 +6,9 @@ package transaction
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -19,7 +21,25 @@ import (
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/wrp-go/v3"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+// bearerFingerprint is the nested log object emitted when credential
+// fingerprinting is enabled. Empty sub-fields are omitted.
+type bearerFingerprint struct {
+	Suffix string
+	SHA    string
+}
+
+func (c bearerFingerprint) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if c.Suffix != "" {
+		enc.AddString("suffix", c.Suffix)
+	}
+	if c.SHA != "" {
+		enc.AddString("sha", c.SHA)
+	}
+	return nil
+}
 
 // XmidtResponse represents the data that a tr1d1um transactor keeps from an HTTP request to
 // the XMiDT API
@@ -160,23 +180,40 @@ func ForwardHeadersByPrefix(p string, from http.Header, to http.Header) {
 	}
 }
 
+// FingerprintConfig controls how incoming Bearer credentials are fingerprinted
+// into request-scoped log fields for tracing/correlation.
+//   - LastNDigits > 0 logs the last N characters of the token as "credSuffix".
+//   - SHA256 true logs the hex-encoded sha256 of the token as "credSHA".
+//
+// When both are set, both fields are logged. When neither is set (zero value),
+// no credential fingerprint is logged.
+type FingerprintConfig struct {
+	SHA256      bool
+	LastNDigits int
+}
+
 // Welcome is an Alice-style constructor that defines necessary request
 // context values assumed to exist by the delegate. These values should
-// be those expected to be used both in and outside the gokit server flow
-func Welcome(delegate http.Handler) http.Handler {
-	return http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			var tid string
+// be those expected to be used both in and outside the gokit server flow.
+// The returned constructor also enriches the request-scoped logger with
+// credential fingerprint fields per the provided FingerprintConfig.
+func Welcome(cfg FingerprintConfig) func(http.Handler) http.Handler {
+	return func(delegate http.Handler) http.Handler {
+		return http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				var tid string
 
-			if tid = r.Header.Get(candlelight.HeaderWPATIDKeyName); tid == "" {
-				tid = genTID()
-			}
+				if tid = r.Header.Get(candlelight.HeaderWPATIDKeyName); tid == "" {
+					tid = genTID()
+				}
 
-			ctx := context.WithValue(r.Context(), ContextKeyRequestTID, tid)
-			ctx = context.WithValue(ctx, ContextKeyRequestArrivalTime, time.Now())
-			ctx = addDeviceIdToLog(ctx, r)
-			delegate.ServeHTTP(w, r.WithContext(ctx))
-		})
+				ctx := context.WithValue(r.Context(), ContextKeyRequestTID, tid)
+				ctx = context.WithValue(ctx, ContextKeyRequestArrivalTime, time.Now())
+				ctx = addDeviceIdToLog(ctx, r)
+				ctx = addBearerFingerprintToLog(ctx, r, cfg)
+				delegate.ServeHTTP(w, r.WithContext(ctx))
+			})
+	}
 }
 
 // genTID generates a 16-byte long string
@@ -200,6 +237,48 @@ func addDeviceIdToLog(ctx context.Context, r *http.Request) context.Context {
 	ctx = sallust.With(ctx, logger)
 
 	return ctx
+}
+
+// addBearerFingerprintToLog enriches the request-scoped logger with credential
+// fingerprint fields per cfg. Nothing is added when cfg is the zero value or
+// when no Bearer token is present.
+func addBearerFingerprintToLog(ctx context.Context, r *http.Request, cfg FingerprintConfig) context.Context {
+	if !cfg.SHA256 && cfg.LastNDigits <= 0 {
+		return ctx
+	}
+	token := bearerToken(r)
+	if token == "" {
+		return ctx
+	}
+
+	var fp bearerFingerprint
+	if cfg.LastNDigits > 0 && len(token) >= cfg.LastNDigits {
+		fp.Suffix = token[len(token)-cfg.LastNDigits:]
+	}
+	if cfg.SHA256 {
+		sum := sha256.Sum256([]byte(token))
+		fp.SHA = hex.EncodeToString(sum[:])
+	}
+	if fp.Suffix == "" && fp.SHA == "" {
+		return ctx
+	}
+
+	logger := sallust.Get(ctx).With(zap.Object("bearerFingerprint", fp))
+	return sallust.With(ctx, logger)
+}
+
+// bearerToken returns the token portion of an "Authorization: Bearer <token>"
+// header, or "" if the header is missing or not a Bearer scheme.
+func bearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return ""
+	}
+	parts := strings.SplitN(auth, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return parts[1]
 }
 
 // getDeviceId extracts device id from the request path params

--- a/transaction/transactor_test.go
+++ b/transaction/transactor_test.go
@@ -6,6 +6,8 @@ package transaction
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -158,7 +160,7 @@ func TestWelcome(t *testing.T) {
 						assert.Equal(tc.expectedTID, tid)
 					}
 				})
-			decorated := Welcome(handler)
+			decorated := Welcome(FingerprintConfig{})(handler)
 			decorated.ServeHTTP(nil, tc.genReq())
 
 		})
@@ -260,6 +262,110 @@ func TestAddDeviceIdToLog(t *testing.T) {
 			assert.Equal("deviceid", gotLog[0].Key)
 			assert.Equal(tc.deviceid, gotLog[0].String)
 
+		})
+	}
+}
+
+func TestBearerToken(t *testing.T) {
+	tests := []struct {
+		desc     string
+		header   string
+		expected string
+	}{
+		{desc: "no header", header: "", expected: ""},
+		{desc: "basic auth ignored", header: "Basic dXNlcjpwYXNz", expected: ""},
+		{desc: "bearer missing token", header: "Bearer", expected: ""},
+		{desc: "happy path", header: "Bearer abc.def.ghi", expected: "abc.def.ghi"},
+		{desc: "case-insensitive scheme", header: "bearer abc.def.ghi", expected: "abc.def.ghi"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert := assert.New(t)
+			r := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			if tc.header != "" {
+				r.Header.Set("Authorization", tc.header)
+			}
+			assert.Equal(tc.expected, bearerToken(r))
+		})
+	}
+}
+
+func TestAddBearerFingerprintToLog(t *testing.T) {
+	const token = "header.payload.abcdefghij1234567890"
+	sum := sha256.Sum256([]byte(token))
+	sha := hex.EncodeToString(sum[:])
+	shortSum := sha256.Sum256([]byte("short"))
+	shortSHA := hex.EncodeToString(shortSum[:])
+
+	tests := []struct {
+		desc     string
+		cfg      FingerprintConfig
+		header   string
+		expected map[string]any // contents of the bearerFingerprint object; nil means no field at all
+	}{
+		{
+			desc:     "default cfg logs nothing even with bearer token",
+			cfg:      FingerprintConfig{},
+			header:   "Bearer " + token,
+			expected: nil,
+		},
+		{
+			desc:     "no bearer header logs nothing",
+			cfg:      FingerprintConfig{SHA256: true, LastNDigits: 10},
+			header:   "",
+			expected: nil,
+		},
+		{
+			desc:     "suffix only",
+			cfg:      FingerprintConfig{LastNDigits: 10},
+			header:   "Bearer " + token,
+			expected: map[string]any{"suffix": "1234567890"},
+		},
+		{
+			desc:     "sha only",
+			cfg:      FingerprintConfig{SHA256: true},
+			header:   "Bearer " + token,
+			expected: map[string]any{"sha": sha},
+		},
+		{
+			desc:     "both",
+			cfg:      FingerprintConfig{SHA256: true, LastNDigits: 10},
+			header:   "Bearer " + token,
+			expected: map[string]any{"suffix": "1234567890", "sha": sha},
+		},
+		{
+			desc:     "suffix requested but token too short is skipped",
+			cfg:      FingerprintConfig{LastNDigits: 10},
+			header:   "Bearer short",
+			expected: nil,
+		},
+		{
+			desc:     "sha still logged when token is shorter than requested suffix",
+			cfg:      FingerprintConfig{SHA256: true, LastNDigits: 10},
+			header:   "Bearer short",
+			expected: map[string]any{"sha": shortSHA},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert := assert.New(t)
+			core, observed := observer.New(zap.DebugLevel)
+			ctx := sallust.With(context.Background(), zap.New(core))
+
+			r := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+			if tc.header != "" {
+				r.Header.Set("Authorization", tc.header)
+			}
+			ctx = addBearerFingerprintToLog(ctx, r, tc.cfg)
+			sallust.Get(ctx).Debug("test")
+
+			ctxMap := observed.All()[0].ContextMap()
+			if tc.expected == nil {
+				_, present := ctxMap["bearerFingerprint"]
+				assert.False(present, "bearerFingerprint should not be present")
+				return
+			}
+			assert.Equal(tc.expected, ctxMap["bearerFingerprint"])
 		})
 	}
 }

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -44,6 +44,7 @@ type Options struct {
 	Log                         *zap.Logger
 	ValidServices               []string
 	ReducedLoggingResponseCodes []int
+	BearerFingerprint             transaction.FingerprintConfig
 }
 
 // ConfigHandler sets up the server that powers the translation service
@@ -61,10 +62,12 @@ func ConfigHandler(c *Options) {
 		opts...,
 	)
 
-	c.APIRouter.Handle("/device/{deviceid}/{service}", c.Authenticate.Then(candlelight.EchoFirstTraceNodeInfo(candlelight.Tracing{}.Propagator(), false)(transaction.Welcome(WRPHandler)))).
+	welcome := transaction.Welcome(c.BearerFingerprint)
+
+	c.APIRouter.Handle("/device/{deviceid}/{service}", c.Authenticate.Then(candlelight.EchoFirstTraceNodeInfo(candlelight.Tracing{}.Propagator(), false)(welcome(WRPHandler)))).
 		Methods(http.MethodGet, http.MethodPatch)
 
-	c.APIRouter.Handle("/device/{deviceid}/{service}/{parameter}", c.Authenticate.Then(candlelight.EchoFirstTraceNodeInfo(candlelight.Tracing{}.Propagator(), false)(transaction.Welcome(WRPHandler)))).
+	c.APIRouter.Handle("/device/{deviceid}/{service}/{parameter}", c.Authenticate.Then(candlelight.EchoFirstTraceNodeInfo(candlelight.Tracing{}.Propagator(), false)(welcome(WRPHandler)))).
 		Methods(http.MethodDelete, http.MethodPut, http.MethodPost)
 }
 

--- a/translation/transport.go
+++ b/translation/transport.go
@@ -44,7 +44,7 @@ type Options struct {
 	Log                         *zap.Logger
 	ValidServices               []string
 	ReducedLoggingResponseCodes []int
-	BearerFingerprint             transaction.FingerprintConfig
+	BearerFingerprint           transaction.FingerprintConfig
 }
 
 // ConfigHandler sets up the server that powers the translation service


### PR DESCRIPTION
Introduce a `fingerprintCreds` config block that enriches per-request logs with a `bearerFingerprint` object containing the last N characters (`suffix`) and/or the SHA-256 (`sha`) of the inbound Bearer token. Both sub-fields are independently toggled; the zero value emits nothing, preserving current behavior.

- transaction.Welcome is now a factory that takes a FingerprintConfig and returns the middleware, so the config flows through stat.Options and translation.Options without global state.
- Fingerprint fields are emitted via a zapcore.ObjectMarshaler so they nest under a single log key without leaking into subsequent fields.
- Wired through fx via the new `fingerprintCreds` viper key with a documented example in tr1d1um.yaml.